### PR TITLE
Updated oauth dependency

### DIFF
--- a/bitballoon.go
+++ b/bitballoon.go
@@ -2,9 +2,9 @@ package bitballoon
 
 import (
 	"bytes"
-	"code.google.com/p/goauth2/oauth"
 	"encoding/json"
 	"errors"
+	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -108,10 +108,14 @@ func NewClient(config *Config) *Client {
 	if config.HttpClient != nil {
 		client.client = config.HttpClient
 	} else if config.AccessToken != "" {
-		t := &oauth.Transport{
-			Token: &oauth.Token{AccessToken: config.AccessToken},
-		}
-		client.client = t.Client()
+		client.client = oauth2.NewClient(
+			oauth2.NoContext,
+			oauth2.StaticTokenSource(
+				&oauth2.Token{
+					AccessToken: config.AccessToken,
+				},
+			),
+		)
 	}
 
 	if &config.UserAgent != nil {

--- a/deploys_test.go
+++ b/deploys_test.go
@@ -136,7 +136,7 @@ func TestDeploysService_Create_Zip(t *testing.T) {
 	mux.HandleFunc("/api/v1/sites/my-site/deploys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		r.ParseForm()
-		if _,ok := r.Form["draft"]; ok {
+		if _, ok := r.Form["draft"]; ok {
 			t.Errorf("Draft should not be a query parameter for a normal deploy")
 		}
 		if r.Header["Content-Type"][0] != "application/zip" {
@@ -158,7 +158,6 @@ func TestDeploysService_Create_Zip(t *testing.T) {
 	}
 }
 
-
 func TestDeploysService_CreateDraft_Zip(t *testing.T) {
 	setup()
 	defer teardown()
@@ -166,7 +165,7 @@ func TestDeploysService_CreateDraft_Zip(t *testing.T) {
 	mux.HandleFunc("/api/v1/sites/my-site/deploys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		r.ParseForm()
-		if val,ok := r.Form["draft"]; ok == false || val[0] != "true" {
+		if val, ok := r.Form["draft"]; ok == false || val[0] != "true" {
 			t.Errorf("Draft should be a true parameter for a draft deploy")
 		}
 		if r.Header["Content-Type"][0] != "application/zip" {


### PR DESCRIPTION
Since code.google.com is deprecated I have updated the dependency to the
new correct path. This is an important change as code.google.com doesn't
work anymore, e.g. package code.google.com/p/goauth2/oauth: unable to
detect version control system for code.google.com/ path

Please merge this ASAP as the DroneCI plugin for bitballoon currently fails to build :(
